### PR TITLE
Hotfix/v0.1.1

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,14 @@
+[build]
+    base = "."
+    publish = "./build"
+    command = "sed -i s/API_URL_PLACEHOLDER/${API_BASE_URL}/g netlify.toml && yarn build"
+
+[[redirects]]
+    from = "/api/*"
+    to = "API_URL_PLACEHOLDER/api/:splat"
+    status = 200
+    
+[[redirects]]
+    from = "/*"
+    to = "/index.html"
+    status = 200

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "labs15",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "dependencies": {
     "axios": "^0.19.0",


### PR DESCRIPTION
# Description
On master, currently, all network requests are hitting typicode's json api so all seems well. On develop, everything is very broken.

This is because the `netlify.toml` file contains the wrong API url. But, since we have two API urls — staging and production — the fix is not as simple as updating the url. 

We need to set these as environment variables via Netlify's GUI. Unfortunately, Netlify does not allow interpolation of environment variables in its `netlify.toml` files. Instead, we can find and replace a placeholder string in the `netlify.toml` file after Netlify builds the app using the [sed](https://linux.die.net/man/1/sed) utility.

The environment variable being set in the Netlify GUI is named `API_BASE_URL`. This variable is set on both the staging site and the production site. Any future updates to the `API_BASE_URL` will be made via the Netlify GUI. 

Check the [Calling Environment Variables](https://www.netlify.com/docs/netlify-toml-reference/) section of the `netlify.toml` docs for more info.
