### PR TITLE
Hotfix/v0.1.2

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
     base = "."
     publish = "./build"
-    command = "sed -i s/API_URL_PLACEHOLDER/$API_BASE_URL/g netlify.toml && yarn build"
+    command = "sed -i s/API_URL_PLACEHOLDER/$REACT_APP_API_BASE_URL/g netlify.toml && yarn build"
 
 [[redirects]]
     from = "/api/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "labs15",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "dependencies": {
     "axios": "^0.19.0",


### PR DESCRIPTION
# Description
#29 got merged too early. Netlify still had build errors. These were probably due to CRA needing `REACT_APP_` prefixes to supplied environment variables. This PR contains that change. Will keep troubleshooting if Netlify still fails building.
