### PR TITLE
Remove 200 status code from netlify toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,6 @@
 [[redirects]]
     from = "/api/*"
     to = "API_URL_PLACEHOLDER/api/:splat"
-    status = 200
     
 [[redirects]]
     from = "/*"


### PR DESCRIPTION
# Description
#30 & #29 both were trying to resolve the same issue as this PR but were merged too early. At least with this PR, the netlify checks are passing again.

I changed some stuff in Netlify's GUI. Notably, I escaped the url strings — in addition to the changes described in #29 & #30. The `sed` utility is functioning as expected now. Before this PR, netlify was ignoring the `netlify.toml` file but, after deploying on a test netlify site locally, it seems the fix might be to remove the `status=200` from the `redirects` array.

Not sure how to test this other than to have this merged and see if we're able to make successful requests to the backend API.

If this doesn't work, I guess the next step would be to try a `_redirects` file instead of a `netlify.toml` file. This would be so much easier if Netlify would allow interpolation of environment variables in the TOML file.
