### PR TITLE
Hotfix/v0.1.4

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,11 +1,16 @@
 [build]
     base = "."
-    publish = "./build"
-    command = "sed -i s/API_URL_PLACEHOLDER/$REACT_APP_API_BASE_URL/g netlify.toml && yarn build"
+    publish = "build"
+    command = "REACT_APP_STAGE=staging yarn build"
 
-[[redirects]]
-    from = "/api/*"
-    to = "API_URL_PLACEHOLDER/api/:splat"
+[context.production]
+    command = "REACT_APP_STAGE=production yarn build"
+
+[context.deploy-preview]
+    command = "REACT_APP_STAGE=staging yarn build"
+
+[context.branch-deploy]
+    command = "REACT_APP_STAGE=staging yarn build"
     
 [[redirects]]
     from = "/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "labs15",
-  "version": "0.1.2",
+  "version": "0.1.4",
   "private": true,
   "dependencies": {
     "axios": "^0.19.0",


### PR DESCRIPTION
I had a bunch of stuff written in this PR description right now and GitHub just destroyed it. 😠 

In any case, this PR is _the one_ that actually solves what #29, #30, and #31 were attempting to solve. 

Going forward, we'll have one environment variable for deployment named `REACT_APP_STAGE`. It's values can be one of either `staging` or `production`. Due to the changes made in this PR, Netlify will automatically set `REACT_APP_STAGE` to `production` when we push to `master`. Likewise, Netlify will set `REACT_APP_STAGE` to `staging` when we push to `develop` — or do any deploy previews.

This will mean that we'll have to handle the url-switching login in our code, which is fine. That change, however, is not in this PR as `master` doesn't currently need it. And `develop` already has it mostly setup. I'll submit a subsequent PR that fully sets this up for `develop` in another PR.