### PR TITLE
Feature/handle-api-endpoints

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,11 +1,16 @@
 [build]
     base = "."
-    publish = "./build"
-    command = "sed -i s/API_URL_PLACEHOLDER/$REACT_APP_API_BASE_URL/g netlify.toml && yarn build"
+    publish = "build"
+    command = "REACT_APP_STAGE=staging yarn build"
 
-[[redirects]]
-    from = "/api/*"
-    to = "API_URL_PLACEHOLDER/api/:splat"
+[context.production]
+    command = "REACT_APP_STAGE=production yarn build"
+
+[context.deploy-preview]
+    command = "REACT_APP_STAGE=staging yarn build"
+
+[context.branch-deploy]
+    command = "REACT_APP_STAGE=staging yarn build"
     
 [[redirects]]
     from = "/*"

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,6 @@
 [[redirects]]
     from = "/api/*"
     to = "API_URL_PLACEHOLDER/api/:splat"
-    status = 200
     
 [[redirects]]
     from = "/*"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
     base = "."
     publish = "./build"
-    command = "sed -i s/API_URL_PLACEHOLDER/$API_BASE_URL/g netlify.toml && yarn build"
+    command = "sed -i s/API_URL_PLACEHOLDER/$REACT_APP_API_BASE_URL/g netlify.toml && yarn build"
 
 [[redirects]]
     from = "/api/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "labs15",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "dependencies": {
     "axios": "^0.19.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "redux-thunk": "^2.3.0",
     "yup": "^0.27.0"
   },
-  "proxy": "http://localhost:5000",
   "scripts": {
     "format": "prettier --write \"**/*.{js,scss,css,html,json,md,less,tsx}\"",
     "start": "react-scripts start",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "labs15",
-  "version": "0.1.2",
+  "version": "0.1.4",
   "private": true,
   "dependencies": {
     "axios": "^0.19.0",

--- a/src/api/config.js
+++ b/src/api/config.js
@@ -1,7 +1,11 @@
 import axios from "axios"
 
+import { configureBaseUrl } from "./utils"
+
+const { REACT_APP_STAGE, REACT_APP_LOCAL_API_PORT } = process.env
+
 const axiosConfig = {
-  baseURL: "/api/v0/"
+  baseURL: configureBaseUrl(REACT_APP_STAGE, REACT_APP_LOCAL_API_PORT)
 }
 
 export const request = () => axios.create({ ...axiosConfig })

--- a/src/api/utils.js
+++ b/src/api/utils.js
@@ -1,0 +1,18 @@
+export const configureBaseUrl = (stage, localApiPort = 5000) => {
+  let baseUrl = ""
+
+  switch (stage) {
+    case "production":
+      baseUrl += "https://endrsd-api.herokuapp.com"
+      break
+
+    case "staging":
+      baseUrl += "https://endrsd-api-staging.herokuapp.com"
+      break
+
+    default:
+      baseUrl += `http://localhost:${localApiPort}`
+  }
+
+  return baseUrl + "/api/v0/"
+}


### PR DESCRIPTION
GitHub deleted what I wrote again! 😲 Why does `cmd + shift + down` replace everything you have with lorem ipsum, irreversibly? Wtf is _that_ about?

# Changelog
- Adds logic to handle switching between the different backend API urls.
- If you want your requests to hit the backend repo (that you already have running locally), run `yarn start` per usual.
    - If that backend repo is running on a port other than `5000`, run `env REACT_APP_LOCAL_API_PORT=<port> yarn start`.
- If you want your requests to hit the staged backend repo (the one on the develop branch of the backend repo), run `env REACT_APP_STAGE=staging yarn start`.
- If you want your requests to hit the production backend repo (the one on the master branch of the backend repo), run `env REACT_APP_STAGE=production yarn start`.