### PR TITLE
Removes 'validateDOMNesting' warnings from console'

### DIFF
--- a/src/components/pages/MyAccount/index.js
+++ b/src/components/pages/MyAccount/index.js
@@ -38,18 +38,20 @@ const MyAccount = () => {
       </div>
       <div className="account-info">
         <table className="account-details">
-          <tr>
-            <td className="labels">First name</td>
-            <td className="content">{user.first_name}</td>
-          </tr>
-          <tr>
-            <td className="labels">Last name</td>
-            <td className="content">{user.last_name}</td>
-          </tr>
-          <tr>
-            <td className="labels">Track</td>
-            <td className="content">{user.tracks_title}</td>
-          </tr>
+          <tbody>
+            <tr>
+              <td className="labels">First name</td>
+              <td className="content">{user.first_name}</td>
+            </tr>
+            <tr>
+              <td className="labels">Last name</td>
+              <td className="content">{user.last_name}</td>
+            </tr>
+            <tr>
+              <td className="labels">Track</td>
+              <td className="content">{user.tracks_title}</td>
+            </tr>
+          </tbody>
         </table>
         <NavLink to="/auth/reset-password">Change Password</NavLink>
       </div>


### PR DESCRIPTION
# Description
- Adds a 'tbody' element as a direct child element of the 'table' element (with 'tr' elements nested inside of it) to get rid of warnings in the console.
- The solution I used was provided in the following facebook thread that addressed the issue [here](https://github.com/facebook/react/issues/12674). 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change Status

- [X] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [X] Manually: Localhost:3000
- [ ] Test B

# Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My code has been reviewed by at least one peer

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] There are no merge conflicts

- Before PR (3 warnings):
<img width="1280" alt="Screen Shot 2019-09-22 at 11 36 51 PM" src="https://user-images.githubusercontent.com/16110931/65401007-6e2ec280-dd93-11e9-997f-4d3fa0ad549b.png">

- After PR (0 warnings):
<img width="1280" alt="Screen Shot 2019-09-22 at 11 42 33 PM" src="https://user-images.githubusercontent.com/16110931/65401026-830b5600-dd93-11e9-822d-f55e27d69614.png">

