### PR TITLE
Feature/sidebar mobile

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -15,6 +15,8 @@ export const createUser = createAsyncAction("CREATE_USER", addUser)
 
 export const logout = () => ({ type: "LOGOUT", payload: null })
 
+export const toggleMenu = (isOpen) => ({ type: "TOGGLE_MENU", payload: isOpen })
+
 export const fetchRequirements = createAsyncAction(
   "FETCH_REQUIREMENTS",
   getRequirements

--- a/src/components/layout/ContentHeader/index.js
+++ b/src/components/layout/ContentHeader/index.js
@@ -7,13 +7,9 @@ import {useMenu} from "../../../hooks"
 import {MenuBurger} from "../../lib"
 import "./index.scss"
 
-<<<<<<< HEAD
 
 const DashboardHeader = ({ title, prompt, progress }) => {
   const {isOpen} = useMenu()
-=======
-const DashboardHeader = ({ title, prompt, progress = 0 }) => {
->>>>>>> 3eb9357a95718802c969b5ac7e4f2b09586b7bfd
   return (
     <header className="header">
       <MenuBurger isOpen={isOpen} />

--- a/src/components/layout/ContentHeader/index.js
+++ b/src/components/layout/ContentHeader/index.js
@@ -2,14 +2,14 @@ import React from "react"
 
 import { ProgressRing, Logo } from "../../lib"
 
-import {useSelector} from "react-redux"
+import {useMenu} from "../../../hooks"
 
 import {MenuBurger} from "../../lib"
 import "./index.scss"
 
 
 const DashboardHeader = ({ title, prompt, progress }) => {
-  const isOpen = useSelector(state => state.menuReducer.isOpen)
+  const {isOpen} = useMenu()
   return (
     <header className="header">
       <MenuBurger isOpen={isOpen} />

--- a/src/components/layout/ContentHeader/index.js
+++ b/src/components/layout/ContentHeader/index.js
@@ -2,11 +2,17 @@ import React from "react"
 
 import { ProgressRing, Logo } from "../../lib"
 
+import {useSelector} from "react-redux"
+
+import {MenuBurger} from "../../lib"
 import "./index.scss"
 
+
 const DashboardHeader = ({ title, prompt, progress }) => {
+  const isOpen = useSelector(state => state.menuReducer.isOpen)
   return (
     <header className="header">
+      <MenuBurger isOpen={isOpen} />
       <Logo></Logo>
       <hgroup>
         <h1>{title}</h1>

--- a/src/components/layout/ContentHeader/index.scss
+++ b/src/components/layout/ContentHeader/index.scss
@@ -129,5 +129,11 @@
     @media screen and (min-width: 1140px) {
       max-width: 10%;
     }
+    @media screen and (min-width: 1140px) {
+      max-width: 10%;
+    }
+    @media screen and (min-width: 1440px) {
+      max-width: 8%;
+    }
   }
 }

--- a/src/components/layout/ContentHeader/index.scss
+++ b/src/components/layout/ContentHeader/index.scss
@@ -20,7 +20,17 @@
     min-height: 9.6rem;
     margin-bottom: 3.2rem;
   }
-
+  .burger {
+    position: absolute;
+    top: -0.4rem;
+    left: 1rem;
+    font-size: 1rem;
+    // height: 1.8em;
+    // width: 2em;
+    @media screen and (min-width: 768px) {
+      display: none;
+    }
+  }
   .logo {
     margin: auto;
     margin-bottom: 4.4rem;

--- a/src/components/layout/ContentHeader/index.scss
+++ b/src/components/layout/ContentHeader/index.scss
@@ -27,6 +27,8 @@
     font-size: 1rem;
     // height: 1.8em;
     // width: 2em;
+    color: blue;
+    grid-column: 2 / span 1;
     @media screen and (min-width: 768px) {
       display: none;
     }
@@ -35,7 +37,7 @@
     margin: auto;
     margin-bottom: 4.4rem;
     width: 50%;
-
+    grid-column: 1 / span 1;
     @media screen and (min-width: 450px) {
       width: 40%;
     }

--- a/src/components/layout/DashboardContent/index.scss
+++ b/src/components/layout/DashboardContent/index.scss
@@ -5,7 +5,7 @@
   flex-direction: column;
   padding: 3.2rem 1.6rem;
   background: $blue-300;
-
+  min-height: 100vh;
   @media screen and (min-width: 450px) {
     padding-right: 3.2rem;
     padding-left: 3.2rem;

--- a/src/components/layout/DashboardLayout/index.js
+++ b/src/components/layout/DashboardLayout/index.js
@@ -16,7 +16,7 @@ import { fetchUser, fetchRequirements } from "../../../actions"
 
 import "./index.scss"
 
-const DashboardLayout = ({ match }) => {
+const DashboardLayout = ({ match, isOpen, width }) => {
   const dispatch = useDispatch()
   const user = useSelector(state => state.userReducer.user)
 
@@ -31,7 +31,7 @@ const DashboardLayout = ({ match }) => {
 
   return (
     <div className="dashboard">
-      <Sidebar></Sidebar>
+      <Sidebar isOpen={isOpen} width={width}></Sidebar>
       <Switch>
         <StudentRoute
           path={`${match.path}requirements/:id`}

--- a/src/components/layout/DashboardLayout/index.js
+++ b/src/components/layout/DashboardLayout/index.js
@@ -16,10 +16,9 @@ import { fetchUser, fetchRequirements } from "../../../actions"
 
 import "./index.scss"
 
-const DashboardLayout = ({ match, isOpen, width }) => {
+const DashboardLayout = ({ match }) => {
   const dispatch = useDispatch()
   const user = useSelector(state => state.userReducer.user)
-
   useEffect(() => {
     const { token, userId } = loadAuthDataFromLocalStorage()
 
@@ -31,7 +30,7 @@ const DashboardLayout = ({ match, isOpen, width }) => {
 
   return (
     <div className="dashboard">
-      <Sidebar isOpen={isOpen} width={width}></Sidebar>
+      <Sidebar></Sidebar>
       <Switch>
         <StudentRoute
           path={`${match.path}requirements/:id`}

--- a/src/components/layout/Sidebar/index.js
+++ b/src/components/layout/Sidebar/index.js
@@ -3,30 +3,32 @@ import React, {useEffect, useState} from "react"
 import "./index.scss"
 
 import { SupportLinks, SidebarHeader, SidebarMenu, Logo, MenuBurger } from "../../lib"
+import {useMenu} from "../../../hooks"
 
-
-
-
-
-const Sidebar = ({isOpen, width}) => {
-  console.log(isOpen, width)
-  const [display, setDisplay] = useState('none')
+const Sidebar = () => {
+  const {isOpen, width} = useMenu()
+  const [left, setLeft] = useState('-2000px')
+  const [position, setPosition] = useState("absolute")
   useEffect(() => {
-    console.log(width, isOpen)
     if (width > 768) {
-      setDisplay('flex')
+      setLeft(0)
+      setPosition('sticky')
     }
     else if (isOpen) {
-      setDisplay('flex')
+      setLeft(0)
+      setPosition('fixed')
     }
     else {
-      setDisplay('none')
+      setLeft('-2000px')
+      setPosition('absolute')
     }
   }, [width, isOpen])
   return (
-    <aside className="dashboard-sidebar" style={{display: display}}>
+    <aside className="dashboard-sidebar" style={{left: left, position: position}}>
+      <div className="logo-area">
       <Logo></Logo>
-      <MenuBurger isOpen={isOpen} />
+      {width <= 768 && <MenuBurger isOpen={isOpen} />}
+      </div>
       <SidebarHeader></SidebarHeader>
       <SidebarMenu></SidebarMenu>
       <SupportLinks></SupportLinks>

--- a/src/components/layout/Sidebar/index.js
+++ b/src/components/layout/Sidebar/index.js
@@ -4,9 +4,9 @@ import "./index.scss"
 
 import { SupportLinks, SidebarHeader, SidebarMenu, Logo } from "../../lib"
 
-const Sidebar = () => {
+const Sidebar = ({isOpen}) => {
   return (
-    <aside className="dashboard-sidebar">
+    <aside className="dashboard-sidebar" style={{display: isOpen ? "flex" : "none"}}>
       <Logo></Logo>
       <SidebarHeader></SidebarHeader>
       <SidebarMenu></SidebarMenu>

--- a/src/components/layout/Sidebar/index.js
+++ b/src/components/layout/Sidebar/index.js
@@ -2,7 +2,11 @@ import React, {useEffect, useState} from "react"
 
 import "./index.scss"
 
-import { SupportLinks, SidebarHeader, SidebarMenu, Logo } from "../../lib"
+import { SupportLinks, SidebarHeader, SidebarMenu, Logo, MenuBurger } from "../../lib"
+
+
+
+
 
 const Sidebar = ({isOpen, width}) => {
   console.log(isOpen, width)
@@ -22,6 +26,7 @@ const Sidebar = ({isOpen, width}) => {
   return (
     <aside className="dashboard-sidebar" style={{display: display}}>
       <Logo></Logo>
+      <MenuBurger isOpen={isOpen} />
       <SidebarHeader></SidebarHeader>
       <SidebarMenu></SidebarMenu>
       <SupportLinks></SupportLinks>

--- a/src/components/layout/Sidebar/index.js
+++ b/src/components/layout/Sidebar/index.js
@@ -1,12 +1,26 @@
-import React from "react"
+import React, {useEffect, useState} from "react"
 
 import "./index.scss"
 
 import { SupportLinks, SidebarHeader, SidebarMenu, Logo } from "../../lib"
 
-const Sidebar = ({isOpen}) => {
+const Sidebar = ({isOpen, width}) => {
+  console.log(isOpen, width)
+  const [display, setDisplay] = useState('none')
+  useEffect(() => {
+    console.log(width, isOpen)
+    if (width > 768) {
+      setDisplay('flex')
+    }
+    else if (isOpen) {
+      setDisplay('flex')
+    }
+    else {
+      setDisplay('none')
+    }
+  }, [width, isOpen])
   return (
-    <aside className="dashboard-sidebar" style={{display: isOpen ? "flex" : "none"}}>
+    <aside className="dashboard-sidebar" style={{display: display}}>
       <Logo></Logo>
       <SidebarHeader></SidebarHeader>
       <SidebarMenu></SidebarMenu>

--- a/src/components/layout/Sidebar/index.scss
+++ b/src/components/layout/Sidebar/index.scss
@@ -12,6 +12,13 @@
   left: 0;
   box-sizing: border-box;
   z-index: 999;
+  .burger {
+    // height: 2.3em;
+    top: 2rem;
+    font-size: 1rem;
+    position: absolute;
+    right: 1.2rem;
+  }
   .my-account-link {
     color: $green-500;
     font-size: 2rem;

--- a/src/components/layout/Sidebar/index.scss
+++ b/src/components/layout/Sidebar/index.scss
@@ -11,7 +11,7 @@
   top: 0;
   left: 0;
   box-sizing: border-box;
-
+  z-index: 999;
   .my-account-link {
     color: $green-500;
     font-size: 2rem;
@@ -20,7 +20,7 @@
   }
 
   @media screen and (min-width: 768px) {
-    display: flex;
+    // display: flex;
   }
 }
 

--- a/src/components/layout/Sidebar/index.scss
+++ b/src/components/layout/Sidebar/index.scss
@@ -1,23 +1,32 @@
 @import "../../../styles/variables";
 
 .dashboard-sidebar {
-  display: none;
+  display: flex;
   flex-direction: column;
   grid-area: sidebar;
   height: 100vh;
   padding: 2.4rem 0;
   background: #081534;
-  position: sticky;
-  top: 0;
-  left: 0;
+  // position: absolute;
   box-sizing: border-box;
+  width: 100%;
   z-index: 999;
+  transition: all 0.25s ease-in-out;
+  .logo-area {
+    width: 100%;
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    align-items: center;
+    justify-items: center;
+    padding: 1rem 0 2rem;
+  }
   .burger {
     // height: 2.3em;
-    top: 2rem;
+    // top: 4.5rem;
     font-size: 1rem;
-    position: absolute;
-    right: 1.2rem;
+    // position: absolute;
+    // right: 1.2rem;
+    grid-column: 3 / span 1;
   }
   .my-account-link {
     color: $green-500;
@@ -27,11 +36,12 @@
   }
 
   @media screen and (min-width: 768px) {
-    // display: flex;
+    // position: sticky;
   }
 }
 
 .dashboard-sidebar .logo {
-  width: 53%;
-  margin: 0 auto 4.4rem;
+  width: 100%;
+  grid-column: 2 / span 1;
+  // margin: 0 auto 4.4rem;
 }

--- a/src/components/lib/MenuBurger/index.js
+++ b/src/components/lib/MenuBurger/index.js
@@ -8,7 +8,6 @@ import '@animated-burgers/burger-rotate/dist/styles.css'
 
 const MenuBurger = ({isOpen}) => {
     const dispatch = useDispatch()
-    console.log(isOpen)
     return <Burger isOpen={isOpen} onClick={() => {
         dispatch(toggleMenu(!isOpen))
       }}/>

--- a/src/components/lib/MenuBurger/index.js
+++ b/src/components/lib/MenuBurger/index.js
@@ -1,0 +1,17 @@
+import React from "react"
+import {useDispatch} from "react-redux"
+import {toggleMenu} from "../../../actions"
+
+import Burger from '@animated-burgers/burger-rotate';
+
+import '@animated-burgers/burger-rotate/dist/styles.css' 
+
+const MenuBurger = ({isOpen}) => {
+    const dispatch = useDispatch()
+    console.log(isOpen)
+    return <Burger isOpen={isOpen} onClick={() => {
+        dispatch(toggleMenu(!isOpen))
+      }}/>
+}
+
+export default MenuBurger

--- a/src/components/lib/MenuItem/index.js
+++ b/src/components/lib/MenuItem/index.js
@@ -1,7 +1,11 @@
 import React, { useState } from "react"
+import {useDispatch} from "react-redux" 
 import { NavLink } from "react-router-dom"
 
+import {toggleMenu} from "../../../actions"
+
 import "./index.scss"
+
 
 const ChildMenuItem = ({ menuItem }) => {
   return (
@@ -16,11 +20,12 @@ const ChildMenuItem = ({ menuItem }) => {
 }
 
 const MenuItem = ({ menuItem }) => {
+  const dispatch = useDispatch();
   const hasChildren = menuItem.children.length > 0
   const [isOpen, setIsOpen] = useState(false)
-
   const handleOpen = () => {
     setIsOpen(!isOpen)
+    dispatch(toggleMenu(false))
   }
 
   return (

--- a/src/components/lib/SupportLinks/index.js
+++ b/src/components/lib/SupportLinks/index.js
@@ -1,36 +1,44 @@
 import React from "react"
+import { useDispatch } from "react-redux"
 
+import { toggleMenu } from "../../../actions"
+
+import uuid from "uuid/v4"
 import "./index.scss"
 
+class LinkInfo {
+  constructor(cssClass, link, iconString) {
+    this.cssClass = cssClass;
+    this.link = link;
+    this.iconString = iconString
+  }
+}
+
+const links = [
+  new LinkInfo("twitter", "https://twitter.com/getendrsd", "fab fa-twitter"), new LinkInfo("slack", "https://lambdaschoolstudents.slack.com/messages/CN99JD9J5", "fab fa-slack"), new LinkInfo( "email", "mailto:labs15superteam@gmail.com", "fas fa-envelope")
+]
+
 const SupportLinks = () => {
+  const dispatch = useDispatch()
   return (
     <div className="support-link-icons">
-      <a
-        className="twitter"
-        href="https://twitter.com/getendrsd"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        <i className="fab fa-twitter"></i>
-      </a>
-      <a
-        className="slack"
-        href="https://lambdaschoolstudents.slack.com/messages/CN99JD9J5"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        <i className="fab fa-slack"></i>
-      </a>
-      <a
-        className="email"
-        href="mailto:labs15superteam@gmail.com"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        <i className="fas fa-envelope"></i>
-      </a>
+      {links.map(({cssClass, link, iconString}) => (
+         <a
+         key={uuid()}
+         className={cssClass}
+         href={link}
+         target="_blank"
+         rel="noopener noreferrer"
+         onClick={() => {
+           dispatch(toggleMenu(false))
+         }}
+       >
+         <i className={iconString}></i>
+       </a>
+      ))}
     </div>
   )
 }
 
 export default SupportLinks
+

--- a/src/components/lib/index.js
+++ b/src/components/lib/index.js
@@ -19,7 +19,7 @@ import MenuItem from "./MenuItem"
 import SearchResults from "./SearchResults"
 import PinnedStudentCard from "./PinnedStudentCard"
 import DeleteModal from "./DeleteModal"
-
+import MenuBurger from "./MenuBurger"
 export {
   FormField,
   SelectFormField,
@@ -41,5 +41,6 @@ export {
   MenuItem,
   SearchResults,
   PinnedStudentCard,
-  DeleteModal
+  DeleteModal,
+  MenuBurger
 }

--- a/src/components/routes/PublicRoute.js
+++ b/src/components/routes/PublicRoute.js
@@ -1,8 +1,15 @@
 import React from "react"
 import { Route } from "react-router-dom"
 
-const PublicRoute = props => {
-  return <Route {...props}></Route>
+import {useMenu} from "../../hooks/"
+import { Sidebar } from "../layout"
+
+const PublicRoute = ({component: Component, ...rest}) => {
+  const isOpen = useMenu()
+  return <Route {...rest} render={(props) => {
+    if (isOpen) return <Sidebar {...props} isOpen />
+    return <Component {...props}/>
+  }}></Route>
 }
 
 export default PublicRoute

--- a/src/components/routes/PublicRoute.js
+++ b/src/components/routes/PublicRoute.js
@@ -1,17 +1,8 @@
 import React from "react"
 import { Route } from "react-router-dom"
 
-import { useMenu } from "../../hooks/"
-import { Sidebar } from "../layout"
-
-const PublicRoute = ({ component: Component, ...rest }) => {
-  const { isOpen, width } = useMenu()
-  return <Route {...rest} render={(props) => {
-    if (width <= 768 && isOpen) { return <Sidebar {...props} isOpen={isOpen} width={width} /> }
-    else {
-      return <Component {...props} width={width} isOpen={isOpen} />
-    }
-  }}></Route>
+const PublicRoute = (props) => {
+  return <Route {...props} ></Route>
 }
 
 export default PublicRoute

--- a/src/components/routes/PublicRoute.js
+++ b/src/components/routes/PublicRoute.js
@@ -1,14 +1,16 @@
 import React from "react"
 import { Route } from "react-router-dom"
 
-import {useMenu} from "../../hooks/"
+import { useMenu } from "../../hooks/"
 import { Sidebar } from "../layout"
 
-const PublicRoute = ({component: Component, ...rest}) => {
-  const isOpen = useMenu()
+const PublicRoute = ({ component: Component, ...rest }) => {
+  const { isOpen, width } = useMenu()
   return <Route {...rest} render={(props) => {
-    if (isOpen) return <Sidebar {...props} isOpen />
-    return <Component {...props}/>
+    if (width <= 768 && isOpen) { return <Sidebar {...props} isOpen={isOpen} width={width} /> }
+    else {
+      return <Component {...props} width={width} isOpen={isOpen} />
+    }
   }}></Route>
 }
 

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -2,5 +2,6 @@ import useGreeting from "./use-greeting"
 import useCountUpToProgress from "./use-count-up-to-progress"
 import useSvgGradient from "./use-svg-gradient"
 import useLogout from "./use-logout"
+import useMenu from "./use-menu"
 
-export { useGreeting, useCountUpToProgress, useSvgGradient, useLogout }
+export { useGreeting, useCountUpToProgress, useSvgGradient, useLogout, useMenu }

--- a/src/hooks/use-menu.js
+++ b/src/hooks/use-menu.js
@@ -1,17 +1,20 @@
 import { useState, useEffect } from "react"
 import { useDispatch, useSelector } from "react-redux"
 
-import { logout } from "../actions"
-import {
-  loadAuthDataFromLocalStorage,
-  clearAuthDataFromLocalStorage,
-  history
-} from "../store"
+import { toggleMenu } from "../actions"
 
 const useMenu = () => {
   const dispatch = useDispatch()
   const isOpen = useSelector(state => state.menuReducer.isOpen)
-  return isOpen
+  const [width, setWidth] = useState(window.innerWidth)
+  useEffect(() => {
+    function handleResize() {
+        setWidth(window.innerWidth);
+    }
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [])
+  return {width, isOpen}
 }
 
 export default useMenu

--- a/src/hooks/use-menu.js
+++ b/src/hooks/use-menu.js
@@ -1,0 +1,17 @@
+import { useState, useEffect } from "react"
+import { useDispatch, useSelector } from "react-redux"
+
+import { logout } from "../actions"
+import {
+  loadAuthDataFromLocalStorage,
+  clearAuthDataFromLocalStorage,
+  history
+} from "../store"
+
+const useMenu = () => {
+  const dispatch = useDispatch()
+  const isOpen = useSelector(state => state.menuReducer.isOpen)
+  return isOpen
+}
+
+export default useMenu

--- a/src/hooks/use-menu.js
+++ b/src/hooks/use-menu.js
@@ -1,10 +1,8 @@
 import { useState, useEffect } from "react"
-import { useDispatch, useSelector } from "react-redux"
+import { useSelector } from "react-redux"
 
-import { toggleMenu } from "../actions"
 
 const useMenu = () => {
-  const dispatch = useDispatch()
   const isOpen = useSelector(state => state.menuReducer.isOpen)
   const [width, setWidth] = useState(window.innerWidth)
   useEffect(() => {

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -5,13 +5,15 @@ import { stepReducer } from "./stepsReducer"
 import { resourceReducer } from "./resourceReducer"
 import { userReducer } from "./userReducer"
 import { studentReducer } from "./studentReducer"
+import { menuReducer } from "./menuReducer"
 
 const appReducer = combineReducers({
   requirementReducer,
   stepReducer,
   resourceReducer,
   userReducer,
-  studentReducer
+  studentReducer,
+  menuReducer
 })
 
 export default (state, action) => {

--- a/src/reducers/menuReducer.js
+++ b/src/reducers/menuReducer.js
@@ -1,0 +1,16 @@
+
+const initialState = {
+  isOpen: false
+}
+
+export const menuReducer = (state = initialState, { type, payload }) => {
+  switch (type) {
+    case "TOGGLE_MENU":
+      return {
+        ...state,
+        isOpen: payload
+      }
+    default:
+      return state
+  }
+}


### PR DESCRIPTION
# Description

Makes the sidebar mobile responsive: adds the use menu hook that gets the width of the screen and the isOpen state from the store. Renders sidebar styles conditionally on isOpen and width. Adjusts the size of progress ring so it does not overlap other elements

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [x] Runs locally
- [ ] Test B

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
